### PR TITLE
task: INSERT or UPDATE

### DIFF
--- a/etl/transformer.py
+++ b/etl/transformer.py
@@ -42,6 +42,7 @@ class Transformer:
         "HS diploma required?": "IsDiplomaRequired",
         "Other prerequisites": "Prerequisites",
         "Anything else to add about the program?": "Miscellaneous",
+        "Row Identifier (DO NOT EDIT)": "gs_row_identifier",
     }
 
     def __init__(self, sheet, spreadsheet_id):
@@ -68,9 +69,8 @@ class Transformer:
 
     def _clean_dataframe(self, df):
         '''
-        This function cleans the dataframe two ways: (1) replaces all empty strings with NaN (to avoid sqlalchemy "invalid input syntax for integer" Error), and (2) removes zeroeth row, which contains header names.
+        This function removes the zeroeth row, which contains header names, from the dataframe.
         '''
-        df_clean = df.replace('', np.nan)
         df_clean.drop(df_clean.index[0], inplace=True)
 
         return df_clean


### PR DESCRIPTION
This PR closes #6.

It works like so:

* every row in the local Google sheets have a UUID (made possible by https://github.com/GIIMSC/GoodwillDataInitiative/pull/292)
* the programs schema uses the UUID as the primary key (see here: https://github.com/brighthive/goodwill-data-resource-schema)
* finally, the Loader ports new data with sqlalchemy's `on_conflict_do_update` (i.e., INSERT a new row, unless the `gs_row_identifier` conflicts with an existing primary key: in that case, UPDATE)

References:
https://docs.sqlalchemy.org/en/13/dialects/postgresql.html#insert-on-conflict-upsert
https://github.com/pandas-dev/pandas/issues/14553#issuecomment-441694764