### PR TITLE
chore: Version of python on ubuntu 18

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,4 +18,4 @@ usaddress = "*"
 converter = {editable = true,git = "https://github.com/brighthive/google-pathways-converter.git",ref = "master"}
 
 [requires]
-python_version = "3.7"
+python_version = "3.6.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ba411f35c6eb05b47ef5c7976137e92fc70a0b064d0fb1d6ccfd806fffea9caa"
+            "sha256": "b1dd566d47f3649fedfc88b500538cba5c42dc647541ccc1bb4b15d84c2aa736"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.6.9"
         },
         "sources": [
             {
@@ -65,10 +65,10 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:0c41a453b9a8e77975bfa436b8daedac00aed1c545d84410daff8272fff40fbb",
-                "sha256:e63b2210e03c4ed829063b72c4af0c4b867c2788efb3210b6b9439b488bd3afd"
+                "sha256:2243db98475f7f2033c41af5185333cbf13780e8f5f96eaadd997c6f34181dcc",
+                "sha256:23cfeeb71d98b7f51cd33650779d35291aeb8b23384976d497805d12eefc6e9b"
             ],
-            "version": "==1.14.1"
+            "version": "==1.14.2"
         },
         "google-auth-httplib2": {
             "hashes": [
@@ -470,11 +470,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:0e5b30f5cb04e887b91b1ee519fa3d89049595f428c1db76e73bd7f17b09b172",
-                "sha256:84dde37075b8805f3d1f392cc47e38a0e59518fb46a431cfdaf7cf1ce805f970"
+                "sha256:95c710d0a72d91c13fae35dce195633c929c3792f54125919847fdcdf7caa0d3",
+                "sha256:eb2b5e935f6a019317e455b6da83dd8650ac9ffd2ee73a7b657a30873d67a698"
             ],
             "index": "pypi",
-            "version": "==5.4.1"
+            "version": "==5.4.2"
         },
         "pytest-mock": {
             "hashes": [


### PR DESCRIPTION
GII servers come with Python 3.6.9. It's easier to downgrade my pipenv.